### PR TITLE
Style: 화면 최대너비 제한 설정 및 커스텀 테마 색상 추가

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "@/styles/globals.css";
+import "@/styles/tailwind.css";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 export default function Home() {
   return (
     <>
-      <div className="bg-amber-300">안녕하세요!</div>
+      <div className="bg-main">Racket Talk</div>
     </>
   );
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -5,3 +5,10 @@ html {
     "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 }
+
+body {
+  max-width: 600px;
+  margin: 0 auto;
+  width: 100%;
+  background-color: white;
+}

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1,4 +1,9 @@
 @import "tailwindcss";
 
 @theme {
+  --color-main: #5621f8;
+  --color-sub: #ff8000;
+  --color-lightPurple: #774aff;
+  --color-charcoal: #2b2b2b;
+  --color-lightGray: #6b6b6b;
 }


### PR DESCRIPTION
## 📌 연관된 이슈 번호

- closes #2 

## 🌱 주요 변경 사항

- 최대 너비 600px 고정
- 화면 가운데 위치하도록 `globals.css` 마진 설정
- `tailwind.css` 에 커스텀 테마 색상 지정
```
@theme {
  --color-main: #5621f8;
  --color-sub: #ff8000;
  --color-lightPurple: #774aff;
  --color-charcoal: #2b2b2b;
  --color-lightGray: #6b6b6b;
}
```
- 사용 방법 -> className="text-main bg-sub"

## 📸 스크린샷 (선택)

<img width="807" alt="스크린샷 2025-05-14 오후 3 24 37" src="https://github.com/user-attachments/assets/6c23b12a-c5bd-48a3-9c2d-2fc2d04a8304" />


